### PR TITLE
Expose package-build options at the top level of build-library

### DIFF
--- a/packages/loom-plugin-build-library/CHANGELOG.md
+++ b/packages/loom-plugin-build-library/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Breaking Change
+
+- Expose options from `loom-plugin-package-build` as top level options instead of nesting them in the `packageBuildOptions` object. [[#253](https://github.com/Shopify/loom/pull/253)]
 
 ## 0.3.2 - 2021-09-13
 

--- a/packages/loom-plugin-build-library/README.md
+++ b/packages/loom-plugin-build-library/README.md
@@ -27,13 +27,21 @@ export default createPackage((pkg) => {
       // Required. A browserslist string that shall be targeted when your runtime includes `Runtime.Browser`
       browserTargets: 'defaults',
       // Required. A browserslist string that shall be targeted when your runtime includes `Runtime.Node`
-      nodeTargets: 'node 12.13',
+      nodeTargets: 'node 12.20',
+      // Optional. Defaults to true. Defines if commonjs outputs should be generated.
+      commonjs: true,
+      // Optional. Defaults to true. Defines if esmodules outputs should be generated.
+      esmodules: true,
+      // Optional. Defaults to true. Defines if esnext outputs should be generated.
+      esnext: true,
+      // Optional. Defaults to true. Defines if entrypoints should be written at
+      // the root of the repository. You can disable this if you have a single
+      // entrypoint or if your package uses the `exports` key in package.json
+      rootEntrypoints: true,
       // Optional. Defaults to false. Defines if graphql files should be processed.
       graphql: false,
       // Optional. Defaults to 'node'. Defines if the jest environment should be 'node' or 'jsdom'.
-      jestEnvironment = 'node',
-      // Optional. Defaults to empty object. Defines any additional config to pass to plugin-package-build
-      packageBuildOptions: {}
+      jestEnvironment: 'node',
     }),
     buildLibraryWorkspace({
       // Optional. Defaults to false. Defines if d.ts files should be generated for graphql files.

--- a/packages/loom-plugin-build-library/src/plugin-build-library.ts
+++ b/packages/loom-plugin-build-library/src/plugin-build-library.ts
@@ -11,25 +11,21 @@ import {rollupConfig} from './plugin-rollup-config';
 import {jestConfig} from './plugin-jest-config';
 import {generateGraphqlTypes} from './plugin-generate-graphql-types';
 
-interface BuildLibraryOptions {
-  browserTargets: string;
-  nodeTargets: string;
+type PackageBuildOptions = Parameters<typeof packageBuild>[0];
+
+type JestEnvironment = Parameters<typeof jestConfig>[0]['jestEnvironment'];
+
+interface BuildLibraryOptions extends PackageBuildOptions {
   readonly graphql?: boolean;
-  readonly jestEnvironment?: Parameters<
-    typeof jestConfig
-  >[0]['jestEnvironment'];
-  readonly packageBuildOptions?: Partial<Parameters<typeof packageBuild>[0]>;
+  readonly jestEnvironment?: JestEnvironment;
 }
 
 export function buildLibrary({
-  browserTargets,
-  nodeTargets,
   graphql = false,
   jestEnvironment = 'node',
-  packageBuildOptions = {},
+  ...packageBuildOptions
 }: BuildLibraryOptions) {
   return createComposedProjectPlugin('Loom.BuildLibrary', [
-    // this needs to be set/ find the babel.config.js file at the root of the proje here as'the't
     babel({
       config: {
         presets: [
@@ -38,10 +34,11 @@ export function buildLibrary({
             {typescript: true, react: true},
           ],
         ],
+        // Disable loading content from babel.config.js
         configFile: false,
       },
     }),
-    packageBuild({browserTargets, nodeTargets, ...packageBuildOptions}),
+    packageBuild(packageBuildOptions),
     rollupConfig({graphql}),
     jestConfig({jestEnvironment}),
   ]);


### PR DESCRIPTION
## Description

Expose package-build options at the top level of `loom-plugin-build-library`

Previously nodeTargets/browserTargets were set at the top level and
everything else was shoved into a packageBuildOptions object. That is
odd and confusing - lets keep all the options together at the top level.


## Type of change

 - loom-plugin-package-build: BREAKING
