### PR TITLE
Fix entrypoint and binfile path generation for non-src directories

### DIFF
--- a/packages/loom-plugin-package-build/CHANGELOG.md
+++ b/packages/loom-plugin-package-build/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Fixed path generation in entrypoints / bin files when the entrypoints do not live in the `src` folder [[#254](https://github.com/Shopify/loom/pull/254)]
 
 ## 0.7.0 - 2021-09-13
 

--- a/packages/loom-plugin-package-build/package.json
+++ b/packages/loom-plugin-package-build/package.json
@@ -34,6 +34,7 @@
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@shopify/loom": "^0.7.0",
     "@shopify/loom-plugin-rollup": "^0.4.0",
+    "common-ancestor-path": "^1.0.1",
     "rollup-plugin-node-externals": "^2.2.0"
   },
   "peerDependencies": {
@@ -43,5 +44,8 @@
     "@shopify/loom-plugin-babel": {
       "optional": true
     }
+  },
+  "devDependencies": {
+    "@types/common-ancestor-path": "^1.0.0"
   }
 }

--- a/packages/loom-plugin-package-build/src/plugin-write-binaries.ts
+++ b/packages/loom-plugin-package-build/src/plugin-write-binaries.ts
@@ -43,7 +43,7 @@ function createWriteBinariesStep({
 
       // This is present as a typeguard that should never trigger as
       // findCommonAncestorPath will only return null if you're on windows and you
-      // feed it files that are on different drives - which should never occuer if
+      // feed it files that are on different drives - which should never occur if
       // you're building a project that is contained within a single folder
       if (commonEntryRoot === null) {
         throw new Error(

--- a/packages/loom-plugin-package-build/src/plugin-write-entrypoints.ts
+++ b/packages/loom-plugin-package-build/src/plugin-write-entrypoints.ts
@@ -88,7 +88,7 @@ async function writeEntries(
 
   // This is present as a typeguard that should never trigger as
   // findCommonAncestorPath will only return null if you're on windows and you
-  // feed it files that are on different drives - which should never occuer if
+  // feed it files that are on different drives - which should never occur if
   // you're building a project that is contained within a single folder
   if (commonEntryRoot === null) {
     throw new Error(

--- a/packages/loom-plugin-package-build/src/plugin-write-entrypoints.ts
+++ b/packages/loom-plugin-package-build/src/plugin-write-entrypoints.ts
@@ -1,10 +1,11 @@
-import {resolve, relative} from 'path';
+import {relative, dirname, join} from 'path';
 
 import {
   Package,
   createProjectBuildPlugin,
   ProjectPluginContext,
 } from '@shopify/loom';
+import findCommonAncestorPath from 'common-ancestor-path';
 
 interface EntryConfig {
   extension: string;
@@ -77,26 +78,39 @@ async function writeEntries(
   project: Package,
   {extension, outputPath, exportStyle}: EntryConfig,
 ) {
-  const sourceRoot = resolve(project.root, 'src');
+  const commonEntryRoot = findCommonAncestorPath(
+    ...(await Promise.all(
+      [...project.entries, ...project.binaries].map(async (entry) =>
+        dirname(require.resolve(entry.root, {paths: [project.root]})),
+      ),
+    )),
+  );
+
+  // This is present as a typeguard that should never trigger as
+  // findCommonAncestorPath will only return null if you're on windows and you
+  // feed it files that are on different drives - which should never occuer if
+  // you're building a project that is contained within a single folder
+  if (commonEntryRoot === null) {
+    throw new Error(
+      'Could not find a common ancestor folder for all your entrypoints',
+    );
+  }
 
   await Promise.all(
-    project.entries.map(async (entry) => {
-      const absoluteEntryPath = (await project.fs.hasFile(`${entry.root}.*`))
-        ? project.fs.resolvePath(entry.root)
-        : project.fs.resolvePath(entry.root, 'index');
+    project.entries.map(async ({name, root}) => {
+      const entryPath = require.resolve(root, {paths: [project.root]});
+      const entryRelativeToCommonRoot = relative(commonEntryRoot, entryPath);
 
-      const relativeFromSourceRoot = relative(sourceRoot, absoluteEntryPath);
-      const destinationInOutput = resolve(outputPath, relativeFromSourceRoot);
-      const relativeFromRoot = `${normalizedRelative(
+      const pathToBuiltEntry = `./${relative(
         project.root,
-        destinationInOutput,
-      )}${extension}`;
+        join(outputPath, entryRelativeToCommonRoot.replace(/\..+$/, extension)),
+      )}`;
 
       if (exportStyle === 'commonjs') {
         // interopRequireDefault copied from https://github.com/babel/babel/blob/56044c7851d583d498f919e9546caddf8f80a72f/packages/babel-helpers/src/helpers.js#L558-L562
-        const linkPath = JSON.stringify(relativeFromRoot);
+        const linkPath = JSON.stringify(pathToBuiltEntry);
         await project.fs.write(
-          `${entry.name || 'index'}${extension}`,
+          `${name || 'index'}${extension}`,
           `function interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : {default: obj};
 }
@@ -111,9 +125,7 @@ module.exports = interopRequireDefault(require(${linkPath}));
       let content = '';
 
       try {
-        content = await project.fs.read(
-          (await project.fs.glob(`${absoluteEntryPath}.*`))[0],
-        );
+        content = await project.fs.read(entryPath);
 
         // export default ...
         // export {Foo as default} from ...
@@ -124,11 +136,11 @@ module.exports = interopRequireDefault(require(${linkPath}));
         // intentional no-op
       }
 
-      const entryExtension = `${entry.name ?? 'index'}${extension}`;
+      const entryExtension = `${name ?? 'index'}${extension}`;
       const entryContents = [
-        `export * from ${JSON.stringify(relativeFromRoot)};`,
+        `export * from ${JSON.stringify(pathToBuiltEntry)};`,
         hasDefault
-          ? `export {default} from ${JSON.stringify(relativeFromRoot)};`
+          ? `export {default} from ${JSON.stringify(pathToBuiltEntry)};`
           : false,
       ]
         .filter(Boolean)
@@ -137,9 +149,4 @@ module.exports = interopRequireDefault(require(${linkPath}));
       await project.fs.write(entryExtension, entryContents);
     }),
   );
-}
-
-function normalizedRelative(from: string, to: string) {
-  const rel = relative(from, to);
-  return rel.startsWith('.') ? rel : `./${rel}`;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2648,6 +2648,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/common-ancestor-path@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/common-ancestor-path/-/common-ancestor-path-1.0.0.tgz#4274e2f96cf193dc42c9af221c6abf3a53f77827"
+  integrity sha512-RuLE14U0ewtlGo81hOjQtzXl3RsVlTkbHqfpsbl9V1hIhAxF30L5ru1Q6C1x7L7d7zs434HbMBeFrdd7fWVQ2Q==
+
 "@types/estree@*", "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -4736,6 +4741,11 @@ commander@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.0.0.tgz#dbf1909b49e5044f8fdaf0adc809f0c0722bdfd0"
   integrity sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==
+
+common-ancestor-path@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz#4f7d2d1394d91b7abdf51871c62f71eadb0182a7"
+  integrity sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==
 
 common-tags@^1.5.1, common-tags@^1.8.0:
   version "1.8.0"


### PR DESCRIPTION
## Description

Previously entry and binfile generation assumed that source code lived
in the `src` directory. However rollup finds the common root of the
entries you specify and uses that as the base when placing output in
the build folder. This meant we were generating import paths when
entries did not live in the `src` folder.

Now we find the common base and use that for generating import paths,
this means that we support both:

- All source files are in a folder not called src
- Source files are spread across multiple folders within your project
  (this is unlikely but rollup handles it so we should too)

## Type of change

- plugin-package-build Patch