### PR TITLE
Refactor how targets are specified in build-library

### DIFF
--- a/config/loom/index.ts
+++ b/config/loom/index.ts
@@ -4,10 +4,7 @@ import {buildLibrary} from '@shopify/loom-plugin-build-library';
 export const createLoomPackagePlugin = () =>
   createComposedProjectPlugin('InternalPackage', [
     buildLibrary({
-      browserTargets: 'defaults',
-      nodeTargets: 'node 12.14.0',
-      esmodules: false,
-      esnext: false,
+      targets: 'node 12.14.0',
       commonjs: true,
       binaries: true,
     }),

--- a/packages/loom-plugin-build-library-extended/README.md
+++ b/packages/loom-plugin-build-library-extended/README.md
@@ -26,10 +26,9 @@ import {
 } from '@shopify/loom-plugin-build-library-extended';
 
 export default createPackage((pkg) => {
-  pkg.runtimes(Runtime.Node, Runtime.Browser);
   pkg.entry({root: './src/index'});
   pkg.use(
-    buildLibrary({browserTargets: 'defaults', nodeTargets: 'node 12.20'}),
+    buildLibrary({targets: 'defaults, node 12.20'}),
     buildLibraryWorkspace(),
     buildLibraryExtended({
       // Optional. Defaults to false. Defines if graphql files should be processed.

--- a/packages/loom-plugin-build-library-extended/src/tests/plugin-build-library-extended.scss.test.ts
+++ b/packages/loom-plugin-build-library-extended/src/tests/plugin-build-library-extended.scss.test.ts
@@ -4,13 +4,17 @@ import {
 } from '../../../../tests/utilities';
 
 const configContent = `
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 import {buildLibrary} from '@shopify/loom-plugin-build-library';
 import {buildLibraryExtended} from '@shopify/loom-plugin-build-library-extended';
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.use(
-    buildLibrary({browserTargets: 'defaults',  nodeTargets: 'node 12'}),
+    buildLibrary({
+      targets: 'node 12.20.0',
+      commonjs: true,
+      esmodules: true,
+      esnext: true,
+    }),
     buildLibraryExtended(),
   );
 });

--- a/packages/loom-plugin-build-library/CHANGELOG.md
+++ b/packages/loom-plugin-build-library/CHANGELOG.md
@@ -11,6 +11,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Removed support for styles, images and graphql files. Support for these file types is now provided by `@shopify/loom-plugin-build-library-extended`. Add that to your loom config as a sibling of `@shopify/loom-plugin-build-library`. [[#256](https://github.com/Shopify/loom/pull/256)]
 - Expose `commonjs`, `esmodules`, `esnext`, `binaries` and `rootEntrypoints` as top level options instead of nesting them in the `packageBuildOptions` object. [[#253](https://github.com/Shopify/loom/pull/253)]
+- The `commonjs`, `esmodules`, `esnext` options now all default to `false` instead of `true`. You must opt into the types of build that you desire. [[#257](https://github.com/Shopify/loom/pull/257)]
+- Merged the `nodeTargets` and `browsersTargets` options into a single required `targets` option. What you specify in `pkg.runtimes` no longer controls how the targets are merged - whatever is in the `targets` option is always used for the commonjs and esmodules builds. [[#257](https://github.com/Shopify/loom/pull/257)]
 
 ### Changed
 

--- a/packages/loom-plugin-build-library/README.md
+++ b/packages/loom-plugin-build-library/README.md
@@ -22,7 +22,7 @@ Add `buildLibrary` and `buildLibraryWorkspace` to your loom plugins.
 By default all build types - `commonjs`, `esmodules` and `esnext` are disabled. You should enable the builds that that you need by setting those options to `true`, along with specifying the required `targets` option based upon what browsers / node versions you wish to support.
 
 ```js
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 import {
   buildLibrary,
   buildLibraryWorkspace,
@@ -38,11 +38,11 @@ export default createPackage((pkg) => {
       // and both if your package targets both
       targets: 'defaults, node 12.20',
       // Optional. Defaults to false. Defines if commonjs outputs should be generated.
-      commonjs: true,
+      commonjs: false,
       // Optional. Defaults to false. Defines if esmodules outputs should be generated.
-      esmodules: true,
+      esmodules: false,
       // Optional. Defaults to false. Defines if esnext outputs should be generated.
-      esnext: true,
+      esnext: false,
       // Optional. Defaults to true. Defines if entrypoints should be written at
       // the root of the repository. You can disable this if you have a single
       // entrypoint or if your package uses the `exports` key in package.json
@@ -61,25 +61,24 @@ export default createPackage((pkg) => {
 
 What targets you specify shall depend upon the type of package you are creating.
 
-- If you are targeting a node-only package you can use `maintained node versions` or an explicit minimum version number like `node 12.20.0`.
-- If you are targeting browsers only you can specify recent versions like `last 3 chrome versions`, or use the [`@shopify/browserslist-config`](https://github.com/Shopify/web-configs/tree/main/packages/browserslist-config) preset like `'extends @shopify/browserslist-config'`.
+- If you are targeting a node-only package you can use `'maintained node versions'` or an explicit minimum version number like `'node 12.20.0'`.
+- If you are targeting browsers only you can specify browserlist defaults like `'defaults'`, recent versions like `last 3 chrome versions`, or use the [`@shopify/browserslist-config`](https://github.com/Shopify/web-configs/tree/main/packages/browserslist-config) preset like `'extends @shopify/browserslist-config'`.
 - If you are targeting both node and browser usage use a comma separated string to join both of the above: `'extends @shopify/browserslist-config, node 12.20.0'`.
 
 You can see what environments these values correspond to by running e.g. `npx browserslist 'defaults'`. If you find these values unclear or are concerned that changes to them may be non-obvious, you can use explicit version numbers instead.
 
 ### Entrypoints
 
-By default, entrypoint files are written to the root of your package that correspond the package's `entry`s defined in its config file. This is to support packages with multiple entrypoints in a world where package.json's [`exports`](https://nodejs.org/api/packages.html#packages_package_entry_points) support is not pervasive as Webpack 4, TypeScript and Jest support is currently absent at time of writing (September 2020).
+By default, entrypoint files are written to the root of your package that correspond the package's `entry`s defined in its config file. This is to support packages with multiple entrypoints in a world where package.json's [`exports`](https://nodejs.org/api/packages.html#packages_package_entry_points) support is not pervasive as Webpack 4, TypeScript and Jest support is currently absent at time of writing (September 2021).
 
 ### Single entrypoint
 
-When creating a package with a single entrypoint, you can set `rootEntrypoints: true` to not write any root entrypoints, and point fields in your package.json to the contents of the build folder.
+When creating a package with a single entrypoint, you can set `rootEntrypoints: false` to not write any root entrypoints, and point fields in your package.json to the contents of the build folder.
 
 Given a `loom.config.js` file that contains:
 
 ```js
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.entry({root: './src/index'});
   buildLibrary({
     targets: 'defaults, node 12.20',
@@ -88,7 +87,7 @@ export default createPackage((pkg) => {
 });
 ```
 
-In the `package.json` add the following `main` (for commonjs output), `module` (for esmodules output), `esnext` (for esnext output) and `types`(for TypeScript types) keys. You can omit a given key if you are not generating a particular output type.
+In the `package.json` add the following `main` (for commonjs output), `module` (for esmodules output), `esnext` (for esnext output) and `types` (for TypeScript types) keys. You can omit a given key if you are not generating a particular output type.
 
 ```js
 {
@@ -107,7 +106,6 @@ Given a `loom.config.js` file that contains:
 
 ```js
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.entry({root: './src/index'});
   pkg.entry({root: './src/second-entry', name: 'second-entry'});
   buildLibrary({
@@ -150,7 +148,7 @@ If a consuming app imports `your-package/second-entry` then it shall load `secon
 We provide an initial babel config that supports typescript and react, using `@shopify/babel-plugin`. If you need to adjust this config, you can call the `babel()` plugin after `buildLibrary` to override the defaults.
 
 ```js
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 import {
   buildLibrary,
   buildLibraryWorkspace,
@@ -183,11 +181,10 @@ export default createPackage((pkg) => {
 When targeting nodejs only, create commonjs output and target a node version.
 
 ```js
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 import {
   buildLibrary,
   buildLibraryWorkspace,
-  babel,
 } from '@shopify/loom-plugin-build-library';
 
 export default createPackage((pkg) => {
@@ -204,11 +201,10 @@ export default createPackage((pkg) => {
 When targeting nodejs and the browser, create commonjs, esmodules and esnext output and target a node version, and extend from Shopify's browserlist config.
 
 ```js
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 import {
   buildLibrary,
   buildLibraryWorkspace,
-  babel,
 } from '@shopify/loom-plugin-build-library';
 
 export default createPackage((pkg) => {

--- a/packages/loom-plugin-build-library/src/plugin-build-library.ts
+++ b/packages/loom-plugin-build-library/src/plugin-build-library.ts
@@ -15,24 +15,22 @@ import {writeEntrypoints} from './plugin-write-entrypoints';
 type JestEnvironment = Parameters<typeof jestConfig>[0]['jestEnvironment'];
 
 interface BuildLibraryOptions {
-  readonly browserTargets: string;
-  readonly nodeTargets: string;
-  readonly binaries?: boolean;
+  readonly targets: string;
   readonly commonjs?: boolean;
   readonly esmodules?: boolean;
   readonly esnext?: boolean;
+  readonly binaries?: boolean;
   readonly rootEntrypoints?: boolean;
   readonly jestEnvironment?: JestEnvironment;
 }
 
 export function buildLibrary({
-  browserTargets,
-  nodeTargets,
+  targets,
+  commonjs = false,
+  esmodules = false,
+  esnext = false,
   binaries = true,
   rootEntrypoints = true,
-  commonjs = true,
-  esmodules = true,
-  esnext = true,
   jestEnvironment = 'node',
 }: BuildLibraryOptions) {
   return createComposedProjectPlugin('Loom.BuildLibrary', [
@@ -50,13 +48,7 @@ export function buildLibrary({
     }),
     rollupHooks(),
     rollupBuild(),
-    rollupConfig({
-      browserTargets,
-      nodeTargets,
-      commonjs,
-      esmodules,
-      esnext,
-    }),
+    rollupConfig({targets, commonjs, esmodules, esnext}),
     jestConfig({jestEnvironment}),
     binaries && writeBinaries(),
     rootEntrypoints && writeEntrypoints({commonjs, esmodules, esnext}),

--- a/packages/loom-plugin-build-library/src/plugin-rollup-config.ts
+++ b/packages/loom-plugin-build-library/src/plugin-rollup-config.ts
@@ -1,7 +1,6 @@
 import {
   createProjectBuildPlugin,
   Package,
-  Runtime,
   DiagnosticError,
 } from '@shopify/loom';
 import babel from '@rollup/plugin-babel';
@@ -18,8 +17,7 @@ declare module '@shopify/loom' {
 }
 
 interface RollupConfigOptions {
-  browserTargets: string;
-  nodeTargets: string;
+  targets: string;
   commonjs: boolean;
   esmodules: boolean;
   esnext: boolean;
@@ -69,12 +67,7 @@ export function rollupConfig(options: RollupConfigOptions) {
             const babelTargets: string[] = [];
 
             if (isDefaultBuild) {
-              if (target.runtime.includes(Runtime.Browser)) {
-                babelTargets.push(options.browserTargets);
-              }
-              if (target.runtime.includes(Runtime.Node)) {
-                babelTargets.push(options.nodeTargets);
-              }
+              babelTargets.push(options.targets);
             } else if (isEsnextBuild) {
               babelTargets.push('last 1 chrome versions');
             }
@@ -138,7 +131,7 @@ export function rollupConfig(options: RollupConfigOptions) {
                 });
               }
             } else if (isEsnextBuild) {
-              if (options.esmodules) {
+              if (options.esnext) {
                 additionalOutputs.push({
                   format: 'esm',
                   dir: project.fs.buildPath('esnext'),

--- a/packages/loom-plugin-build-library/src/tests/plugin-build-library.test.ts
+++ b/packages/loom-plugin-build-library/src/tests/plugin-build-library.test.ts
@@ -234,7 +234,7 @@ export function pkg(greet) {
     // using target: "node 12, chrome 10", exponentiation not supported, so should transpile
     ['"node 12, chrome 10"', 'var x = Math.pow(2, 2);'],
   ])(
-    'transpiles js content when runtime is %p',
+    'transpiles js content when targets is %p',
     async (targets, expectedOutput) => {
       await withWorkspace(generateUniqueWorkspaceID(), async (workspace) => {
         await workspace.writeConfig(`

--- a/packages/loom-plugin-build-library/src/tests/plugin-build-library.test.ts
+++ b/packages/loom-plugin-build-library/src/tests/plugin-build-library.test.ts
@@ -4,17 +4,53 @@ import {
 } from '../../../../tests/utilities';
 
 describe('@shopify/loom-plugin-build-library buildLibrary', () => {
-  it('builds commmonjs, esmodules and esnext outputs by default', async () => {
+  it('builds nothing by default', async () => {
     await withWorkspace(generateUniqueWorkspaceID(), async (workspace) => {
       await workspace.writeConfig(`
-        import {createPackage, Runtime} from '@shopify/loom';
+        import {createPackage} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
-          pkg.runtime(Runtime.Node);
+          pkg.use(
+            buildLibrary({targets: 'chrome 88, node 12'}),
+          );
+        });
+      `);
+
+      await workspace.writeFile(
+        'src/index.js',
+        `
+export function pkg(greet) {
+  console.log(\`Hello, \${greet}!\`);
+}
+        `,
+      );
+
+      await workspace.run('build');
+
+      // Build content
+      expect(await workspace.contains('build/cjs')).toBeFalsy();
+      expect(await workspace.contains('build/esm')).toBeFalsy();
+      expect(await workspace.contains('build/esnext')).toBeFalsy();
+
+      // Entrypoints
+      expect(await workspace.contains('index.js')).toBeFalsy();
+      expect(await workspace.contains('index.mjs')).toBeFalsy();
+      expect(await workspace.contains('index.esnext')).toBeFalsy();
+    });
+  });
+
+  it('builds commmonjs, esmodules and esnext outputs when configured', async () => {
+    await withWorkspace(generateUniqueWorkspaceID(), async (workspace) => {
+      await workspace.writeConfig(`
+        import {createPackage} from '@shopify/loom';
+        import {buildLibrary} from '@shopify/loom-plugin-build-library';
+        export default createPackage((pkg) => {
           pkg.use(
             buildLibrary({
-              browserTargets: 'chrome 88',
-              nodeTargets: 'node 12',
+              targets: 'chrome 88, node 12',
+              commonjs: true,
+              esmodules: true,
+              esnext: true,
             }),
           );
         });
@@ -67,17 +103,11 @@ function pkg(greet) {
   it('builds only commmonjs outputs when esmodules/esnext are disabled', async () => {
     await withWorkspace(generateUniqueWorkspaceID(), async (workspace) => {
       await workspace.writeConfig(`
-        import {createPackage, Runtime} from '@shopify/loom';
+        import {createPackage} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
-          pkg.runtime(Runtime.Node);
           pkg.use(
-            buildLibrary({
-              esmodules: false,
-              esnext: false,
-              browserTargets: 'chrome 88',
-              nodeTargets: 'node 12',
-            }),
+            buildLibrary({targets: 'node 12', commonjs: true}),
           );
         });
       `);
@@ -108,20 +138,14 @@ export function pkg(greet) {
   it('builds multiple entrypoints', async () => {
     await withWorkspace(generateUniqueWorkspaceID(), async (workspace) => {
       await workspace.writeConfig(`
-        import {createPackage, Runtime} from '@shopify/loom';
+        import {createPackage} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
           pkg.entry({root: './src/index'});
           pkg.entry({name: 'second', root: './src/second'});
           pkg.binary({name: 'cmd', root: './src/cmd'});
-          pkg.runtime(Runtime.Node);
           pkg.use(
-            buildLibrary({
-              esmodules: false,
-              esnext: false,
-              browserTargets: 'chrome 88',
-              nodeTargets: 'node 12',
-            }),
+            buildLibrary({targets: 'node 12', commonjs: true}),
           );
         });
       `);
@@ -149,18 +173,12 @@ export function pkg(greet) {
   it('generates binary files', async () => {
     await withWorkspace(generateUniqueWorkspaceID(), async (workspace) => {
       await workspace.writeConfig(`
-        import {createPackage, Runtime} from '@shopify/loom';
+        import {createPackage} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
           pkg.binary({name: 'cmd', root: './src/index'});
-          pkg.runtime(Runtime.Node);
           pkg.use(
-            buildLibrary({
-              esmodules: false,
-              esnext: false,
-              browserTargets: 'chrome 88',
-              nodeTargets: 'node 12',
-            }),
+            buildLibrary({targets: 'node 12', commonjs: true}),
           );
         });
       `);
@@ -184,14 +202,13 @@ export function pkg(greet) {
   it('can disable generation of root entrypoints', async () => {
     await withWorkspace(generateUniqueWorkspaceID(), async (workspace) => {
       await workspace.writeConfig(`
-          import {createPackage, Runtime} from '@shopify/loom';
+          import {createPackage} from '@shopify/loom';
           import {packageBuild} from '@shopify/loom-plugin-build-library';
           export default createPackage((pkg) => {
-            pkg.runtime(Runtime.Node);
             pkg.use(
               buildLibrary({
-                browserTargets: 'chrome 88',
-                nodeTargets: 'node 12',
+                targets: 'chrome 88, node 12',
+                commonjs: true,
                 rootEntrypoints: false,
               }),
             );
@@ -210,27 +227,25 @@ export function pkg(greet) {
   });
 
   it.each([
-    // uses target: "node 12", exponentiation supported, so should not transpile
-    ['Runtime.Node', 'const x = 2 ** 2;'],
-    // uses target: "chrome 10", exponentiation not supported, so should transpile
-    ['Runtime.Browser', 'var x = Math.pow(2, 2);'],
-    // uses target: "node 12, chrome 10", exponentiation not supported, so should transpile
-    ['Runtime.Node, Runtime.Browser', 'var x = Math.pow(2, 2);'],
+    // using target: "node 12", exponentiation supported, so should not transpile
+    ['"node 12"', 'const x = 2 ** 2;'],
+    // using target: "chrome 10", exponentiation not supported, so should transpile
+    ['"chrome 10"', 'var x = Math.pow(2, 2);'],
+    // using target: "node 12, chrome 10", exponentiation not supported, so should transpile
+    ['"node 12, chrome 10"', 'var x = Math.pow(2, 2);'],
   ])(
     'transpiles js content when runtime is %p',
-    async (runtimes, expectedOutput) => {
+    async (targets, expectedOutput) => {
       await withWorkspace(generateUniqueWorkspaceID(), async (workspace) => {
         await workspace.writeConfig(`
         import {createPackage, Runtime} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
-          pkg.runtimes(${runtimes});
           pkg.use(
             buildLibrary({
-              // Needs to transpile exponentiation
-              browserTargets: 'chrome 10',
-              // Doesn't need to transpile exponentiation
-              nodeTargets: 'node 12',
+              targets: ${targets},
+              esmodules: true,
+              esnext: true,
             }),
           );
         });
@@ -257,16 +272,16 @@ export function pkg(greet) {
   it('builds entries and binaries when the source is not in the src directory', async () => {
     await withWorkspace(generateUniqueWorkspaceID(), async (workspace) => {
       await workspace.writeConfig(`
-        import {createPackage, Runtime} from '@shopify/loom';
+        import {createPackage} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
           pkg.entry({root: './js/index'});
-          pkg.runtime(Runtime.Node);
           pkg.use(
             buildLibrary({
-              browserTargets: 'chrome 88',
-              nodeTargets: 'node 12',
-
+              targets: 'chrome 88, node 12',
+              commonjs:true,
+              esmodules: true,
+              esnext: true,
             }),
           );
         });
@@ -299,17 +314,18 @@ export function pkg(greet) {
   it('builds entries and binaries when the source is spread across multiple folders', async () => {
     await withWorkspace(generateUniqueWorkspaceID(), async (workspace) => {
       await workspace.writeConfig(`
-        import {createPackage, Runtime} from '@shopify/loom';
+        import {createPackage} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
           pkg.entry({root: './src/index'});
           pkg.entry({name: 'second', root: './js/second'});
           pkg.binary({name: 'cmd', root: './cmd/cmd'});
-          pkg.runtime(Runtime.Node);
           pkg.use(
             buildLibrary({
-              browserTargets: 'chrome 88',
-              nodeTargets: 'node 12',
+              targets: 'chrome 88, node 12',
+              commonjs: true,
+              esmodules: true,
+              esnext: true,
             }),
           );
         });
@@ -377,15 +393,11 @@ export function pkg(greet) {
   it('builds tsx files', async () => {
     await withWorkspace(generateUniqueWorkspaceID(), async (workspace) => {
       await workspace.writeConfig(`
-        import {createPackage, Runtime} from '@shopify/loom';
+        import {createPackage} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
-          pkg.runtime(Runtime.Node);
           pkg.use(
-            buildLibrary({
-              browserTargets: 'chrome 88',
-              nodeTargets: 'node 12',
-            }),
+            buildLibrary({targets: 'chrome 88, node 12', esmodules: 'true'}),
           );
         });
       `);


### PR DESCRIPTION
## Description

Previously there were two required options: `nodeTargets` and
`browserTargets` and these were combined based upon what Runtimes you
specified. Also all build outputs were generated by default.

This caused uglyness in nodejs-only packages as you had to write a
meaningless required option in browserTargets, and you had to disable
esmodules/esnext build outputs.

A better solution is to make all build targets opt-in, and have a single
`targets` option where it is up to the user to combin node and browser
targets. This results in simpler config for node-js only packages, and
makes how targets are resolved clearer to understand for packages that
target node and the browser

## Type of change


- plugin-package-build Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
