### PR TITLE
Simplify jest babel transform

### DIFF
--- a/packages/loom-plugin-jest/CHANGELOG.md
+++ b/packages/loom-plugin-jest/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Pass babel options directly into `babel-jest` instead of having to create an intermediate tranform file.
 
 ## 0.6.0 - 2021-09-13
 

--- a/packages/loom-plugin-jest/CHANGELOG.md
+++ b/packages/loom-plugin-jest/CHANGELOG.md
@@ -9,7 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Pass babel options directly into `babel-jest` instead of having to create an intermediate tranform file.
+- Pass babel options directly into `babel-jest` instead of having to create an intermediate transform file. [[#258](https://github.com/Shopify/loom/pull/258)]
 
 ## 0.6.0 - 2021-09-13
 


### PR DESCRIPTION
## Description

Previously we wrote a custom file for babel transforms to include our
config options. However this can be avoided by passing options directly
to babel-config.

This commit calls babel-jest with options instead of writing an
intermediate config file, reducing the amount of temporary files needed.

## Type of change

- plugin-jest Patch: Bug (non-breaking change which fixes an issue)
