### PR TITLE
Entryfile loading improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "plop": "^2.7.4",
     "prettier": "^2.0.4",
     "resolve": "^1.20.0",
+    "strip-ansi": "^6.0.0",
     "tree-node-cli": "^1.3.0"
   },
   "dependencies": {},

--- a/packages/loom-cli/loom.config.ts
+++ b/packages/loom-cli/loom.config.ts
@@ -1,10 +1,9 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
-  pkg.entry({root: './src/index'});
-  pkg.binary({name: 'loom', root: './src/cli'});
+  pkg.entry({root: './src/index.ts'});
+  pkg.binary({name: 'loom', root: './src/cli.ts'});
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-babel/README.md
+++ b/packages/loom-plugin-babel/README.md
@@ -19,7 +19,6 @@ import {createPackage, Runtime} from '@shopify/loom';
 import {babel} from '@shopify/loom-plugin-babel';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.use(
     babel({
       // Overrides any current config that is set
@@ -34,7 +33,6 @@ import {createPackage, Runtime} from '@shopify/loom';
 import {babel} from '@shopify/loom-plugin-babel';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.use(
     // Override initial babel options.
     // Return a new object, instead of mutating the argument object.

--- a/packages/loom-plugin-babel/loom.config.ts
+++ b/packages/loom-plugin-babel/loom.config.ts
@@ -1,9 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
-  pkg.entry({root: './src/index'});
+  pkg.entry({root: './src/index.ts'});
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-babel/src/tests/plugin-babel.test.ts
+++ b/packages/loom-plugin-babel/src/tests/plugin-babel.test.ts
@@ -39,7 +39,7 @@ describe('@shopify/loom-plugin-babel', () => {
 
       const result = await workspace.run('build');
 
-      expect(result.stdout).toContain('BabelConfig: {}');
+      expect(result.stdout()).toContain('BabelConfig: {}');
     });
   });
 
@@ -59,7 +59,7 @@ describe('@shopify/loom-plugin-babel', () => {
 
       const result = await workspace.run('build');
       const expectedConfig = {presets: ['my-plugin']};
-      expect(result.stdout).toContain(
+      expect(result.stdout()).toContain(
         `BabelConfig: ${JSON.stringify(expectedConfig)}`,
       );
     });
@@ -85,7 +85,7 @@ describe('@shopify/loom-plugin-babel', () => {
 
       const result = await workspace.run('build');
       const expectedConfig = {presets: ['my-plugin']};
-      expect(result.stdout).toContain(
+      expect(result.stdout()).toContain(
         `BabelConfig: ${JSON.stringify(expectedConfig)}`,
       );
     });
@@ -112,7 +112,7 @@ describe('@shopify/loom-plugin-babel', () => {
 
       const result = await workspace.run('build');
       const expectedConfig = {presets: ['my-new-plugin']};
-      expect(result.stdout).toContain(
+      expect(result.stdout()).toContain(
         `BabelConfig: ${JSON.stringify(expectedConfig)}`,
       );
     });
@@ -142,7 +142,7 @@ describe('@shopify/loom-plugin-babel', () => {
 
       const result = await workspace.run('build');
       const expectedConfig = {presets: ['my-plugin', 'my-new-plugin']};
-      expect(result.stdout).toContain(
+      expect(result.stdout()).toContain(
         `BabelConfig: ${JSON.stringify(expectedConfig)}`,
       );
     });

--- a/packages/loom-plugin-build-library-extended/README.md
+++ b/packages/loom-plugin-build-library-extended/README.md
@@ -26,7 +26,7 @@ import {
 } from '@shopify/loom-plugin-build-library-extended';
 
 export default createPackage((pkg) => {
-  pkg.entry({root: './src/index'});
+  pkg.entry({root: './src/index.js'});
   pkg.use(
     buildLibrary({targets: 'defaults, node 12.20'}),
     buildLibraryWorkspace(),

--- a/packages/loom-plugin-build-library-extended/loom.config.ts
+++ b/packages/loom-plugin-build-library-extended/loom.config.ts
@@ -1,11 +1,10 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
-  pkg.entry({root: './src/index'});
-  pkg.entry({name: 'transform-style', root: './src/jest/transform-style'});
-  pkg.entry({name: 'transform-svg', root: './src/jest/transform-svg'});
+  pkg.entry({root: './src/index.ts'});
+  pkg.entry({name: 'transform-style', root: './src/jest/transform-style.ts'});
+  pkg.entry({name: 'transform-svg', root: './src/jest/transform-svg.ts'});
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-build-library-extended/src/tests/plugin-build-library-extended.scss.test.ts
+++ b/packages/loom-plugin-build-library-extended/src/tests/plugin-build-library-extended.scss.test.ts
@@ -8,6 +8,7 @@ import {createPackage} from '@shopify/loom';
 import {buildLibrary} from '@shopify/loom-plugin-build-library';
 import {buildLibraryExtended} from '@shopify/loom-plugin-build-library-extended';
 export default createPackage((pkg) => {
+  pkg.entry({root: './src/index.js'});
   pkg.use(
     buildLibrary({
       targets: 'node 12.20.0',

--- a/packages/loom-plugin-build-library/README.md
+++ b/packages/loom-plugin-build-library/README.md
@@ -29,7 +29,7 @@ import {
 } from '@shopify/loom-plugin-build-library';
 
 export default createPackage((pkg) => {
-  pkg.entry({root: './src/index'});
+  pkg.entry({root: './src/index.js'});
   pkg.use(
     buildLibrary({
       // Required. A browserslist string for specifying your target output.
@@ -79,7 +79,7 @@ Given a `loom.config.js` file that contains:
 
 ```js
 export default createPackage((pkg) => {
-  pkg.entry({root: './src/index'});
+  pkg.entry({root: './src/index.js'});
   buildLibrary({
     targets: 'defaults, node 12.20',
     rootEntrypoints: false,
@@ -106,8 +106,8 @@ Given a `loom.config.js` file that contains:
 
 ```js
 export default createPackage((pkg) => {
-  pkg.entry({root: './src/index'});
-  pkg.entry({root: './src/second-entry', name: 'second-entry'});
+  pkg.entry({root: './src/index.js'});
+  pkg.entry({root: './src/second-entry.js', name: 'second-entry'});
   buildLibrary({
     targets: 'defaults, node 12.20',
     rootEntrypoints: true,
@@ -156,7 +156,7 @@ import {
 } from '@shopify/loom-plugin-build-library';
 
 export default createPackage((pkg) => {
-  pkg.entry({root: './src/index'});
+  pkg.entry({root: './src/index.js'});
   pkg.use(
     buildLibrary({targets: 'node 12.20.0', commonjs: true}),
     buildLibraryWorkspace(),
@@ -188,7 +188,7 @@ import {
 } from '@shopify/loom-plugin-build-library';
 
 export default createPackage((pkg) => {
-  pkg.entry({root: './src/index'});
+  pkg.entry({root: './src/index.js'});
   pkg.use(
     buildLibrary({targets: 'node 12.20.0', commonjs: true}),
     buildLibraryWorkspace(),
@@ -208,7 +208,7 @@ import {
 } from '@shopify/loom-plugin-build-library';
 
 export default createPackage((pkg) => {
-  pkg.entry({root: './src/index'});
+  pkg.entry({root: './src/index.js'});
   pkg.use(
     buildLibrary({
       targets: 'extends @shopify/browserslist-config, node 12.20.0',

--- a/packages/loom-plugin-build-library/loom.config.ts
+++ b/packages/loom-plugin-build-library/loom.config.ts
@@ -1,9 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
-  pkg.entry({root: './src/index'});
+  pkg.entry({root: './src/index.ts'});
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-build-library/src/plugin-write-binaries.ts
+++ b/packages/loom-plugin-build-library/src/plugin-write-binaries.ts
@@ -35,8 +35,8 @@ function createWriteBinariesStep({
     async (step) => {
       const commonEntryRoot = findCommonAncestorPath(
         ...(await Promise.all(
-          [...project.entries, ...project.binaries].map(async (entry) =>
-            dirname(require.resolve(entry.root, {paths: [project.root]})),
+          [...project.entries, ...project.binaries].map(async ({root}) =>
+            dirname(project.fs.resolvePath(root)),
           ),
         )),
       );
@@ -53,9 +53,7 @@ function createWriteBinariesStep({
 
       await Promise.all(
         project.binaries.map(async ({name, root, aliases = []}) => {
-          const binaryPath = require.resolve(root, {
-            paths: [project.root],
-          });
+          const binaryPath = project.fs.resolvePath(root);
           const sourceFileRelativeToCommonRoot = relative(
             commonEntryRoot,
             binaryPath,

--- a/packages/loom-plugin-build-library/src/plugin-write-entrypoints.ts
+++ b/packages/loom-plugin-build-library/src/plugin-write-entrypoints.ts
@@ -80,8 +80,8 @@ async function writeEntries(
 ) {
   const commonEntryRoot = findCommonAncestorPath(
     ...(await Promise.all(
-      [...project.entries, ...project.binaries].map(async (entry) =>
-        dirname(require.resolve(entry.root, {paths: [project.root]})),
+      [...project.entries, ...project.binaries].map(async ({root}) =>
+        dirname(project.fs.resolvePath(root)),
       ),
     )),
   );
@@ -98,7 +98,7 @@ async function writeEntries(
 
   await Promise.all(
     project.entries.map(async ({name, root}) => {
-      const entryPath = require.resolve(root, {paths: [project.root]});
+      const entryPath = project.fs.resolvePath(root);
       const entryRelativeToCommonRoot = relative(commonEntryRoot, entryPath);
 
       const pathToBuiltEntry = `./${relative(

--- a/packages/loom-plugin-build-library/src/tests/plugin-build-library.errors.test.ts
+++ b/packages/loom-plugin-build-library/src/tests/plugin-build-library.errors.test.ts
@@ -1,0 +1,69 @@
+import {
+  withWorkspace,
+  generateUniqueWorkspaceID,
+} from '../../../../tests/utilities';
+
+describe('@shopify/loom-plugin-build-library buildLibrary', () => {
+  it('throws an error if you do not specify any entries', async () => {
+    const workspaceId = generateUniqueWorkspaceID();
+
+    await withWorkspace(workspaceId, async (workspace) => {
+      await workspace.writeConfig(`
+        import {createPackage} from '@shopify/loom';
+        import {buildLibrary} from '@shopify/loom-plugin-build-library';
+        export default createPackage((pkg) => {
+          pkg.use(
+            buildLibrary({targets: 'node 12'}),
+          );
+        });
+      `);
+
+      await workspace.writeFile('src/index.js', `export const x = 1;`);
+
+      const result = await workspace.run('build');
+
+      expect(result.stdout()).toContain(
+        `failed during step build package ${workspaceId} variant`,
+      );
+
+      expect(result.stdout()).not.toContain('build completed successfully');
+
+      expect(result.stderr()).toContain(
+        `No inputs found for "${workspaceId}".`,
+      );
+    });
+  });
+
+  it('throws an error if you specify an entry/binary that does not exist on disk', async () => {
+    const workspaceId = generateUniqueWorkspaceID();
+
+    await withWorkspace(workspaceId, async (workspace) => {
+      await workspace.writeConfig(`
+        import {createPackage} from '@shopify/loom';
+        import {buildLibrary} from '@shopify/loom-plugin-build-library';
+        export default createPackage((pkg) => {
+          // Real file papth is src/index.js
+          pkg.entry({root: './src/index'})
+          pkg.binary({root: './src/index2.js'})
+          pkg.use(
+            buildLibrary({targets: 'node 12'}),
+          );
+        });
+      `);
+
+      await workspace.writeFile('src/index.js', `export const x = 1;`);
+
+      const result = await workspace.run('build');
+
+      expect(result.stdout()).toContain(
+        `failed during step build package ${workspaceId} variant`,
+      );
+
+      expect(result.stdout()).not.toContain('build completed successfully');
+
+      expect(result.stderr()).toContain(
+        `The following entry/binary root paths were defined in "${workspaceId}" but do not exist on disk: "./src/index", "./src/index2.js".`,
+      );
+    });
+  });
+});

--- a/packages/loom-plugin-build-library/src/tests/plugin-build-library.test.ts
+++ b/packages/loom-plugin-build-library/src/tests/plugin-build-library.test.ts
@@ -10,6 +10,7 @@ describe('@shopify/loom-plugin-build-library buildLibrary', () => {
         import {createPackage} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
+          pkg.entry({root: './src/index.js'});
           pkg.use(
             buildLibrary({targets: 'chrome 88, node 12'}),
           );
@@ -45,6 +46,7 @@ export function pkg(greet) {
         import {createPackage} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
+          pkg.entry({root: './src/index.js'});
           pkg.use(
             buildLibrary({
               targets: 'chrome 88, node 12',
@@ -106,6 +108,7 @@ function pkg(greet) {
         import {createPackage} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
+          pkg.entry({root: './src/index.js'});
           pkg.use(
             buildLibrary({targets: 'node 12', commonjs: true}),
           );
@@ -141,9 +144,9 @@ export function pkg(greet) {
         import {createPackage} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
-          pkg.entry({root: './src/index'});
-          pkg.entry({name: 'second', root: './src/second'});
-          pkg.binary({name: 'cmd', root: './src/cmd'});
+          pkg.entry({root: './src/index.js'});
+          pkg.entry({name: 'second', root: './src/second.js'});
+          pkg.binary({name: 'cmd', root: './src/cmd.js'});
           pkg.use(
             buildLibrary({targets: 'node 12', commonjs: true}),
           );
@@ -176,7 +179,8 @@ export function pkg(greet) {
         import {createPackage} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
-          pkg.binary({name: 'cmd', root: './src/index'});
+          pkg.entry({root: './src/index.js'});
+          pkg.binary({name: 'cmd', root: './src/index.js'});
           pkg.use(
             buildLibrary({targets: 'node 12', commonjs: true}),
           );
@@ -205,6 +209,7 @@ export function pkg(greet) {
           import {createPackage} from '@shopify/loom';
           import {packageBuild} from '@shopify/loom-plugin-build-library';
           export default createPackage((pkg) => {
+            pkg.entry({root: './src/index.js'});
             pkg.use(
               buildLibrary({
                 targets: 'chrome 88, node 12',
@@ -241,6 +246,7 @@ export function pkg(greet) {
         import {createPackage, Runtime} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
+          pkg.entry({root: './src/index.js'});
           pkg.use(
             buildLibrary({
               targets: ${targets},
@@ -275,7 +281,7 @@ export function pkg(greet) {
         import {createPackage} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
-          pkg.entry({root: './js/index'});
+          pkg.entry({root: './js/index.js'});
           pkg.use(
             buildLibrary({
               targets: 'chrome 88, node 12',
@@ -317,9 +323,9 @@ export function pkg(greet) {
         import {createPackage} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
-          pkg.entry({root: './src/index'});
-          pkg.entry({name: 'second', root: './js/second'});
-          pkg.binary({name: 'cmd', root: './cmd/cmd'});
+          pkg.entry({root: './src/index.js'});
+          pkg.entry({name: 'second', root: './js/second/index.js'});
+          pkg.binary({name: 'cmd', root: './cmd/cmd.js'});
           pkg.use(
             buildLibrary({
               targets: 'chrome 88, node 12',
@@ -396,6 +402,7 @@ export function pkg(greet) {
         import {createPackage} from '@shopify/loom';
         import {buildLibrary} from '@shopify/loom-plugin-build-library';
         export default createPackage((pkg) => {
+          pkg.entry({root: './src/index.tsx'});
           pkg.use(
             buildLibrary({targets: 'chrome 88, node 12', esmodules: 'true'}),
           );

--- a/packages/loom-plugin-eslint/loom.config.ts
+++ b/packages/loom-plugin-eslint/loom.config.ts
@@ -1,8 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
+  pkg.entry({root: './src/index.ts'});
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-jest/loom.config.ts
+++ b/packages/loom-plugin-jest/loom.config.ts
@@ -1,8 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
+  pkg.entry({root: './src/index.ts'});
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-prettier/loom.config.ts
+++ b/packages/loom-plugin-prettier/loom.config.ts
@@ -1,8 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
+  pkg.entry({root: './src/index.ts'});
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-rollup/loom.config.ts
+++ b/packages/loom-plugin-rollup/loom.config.ts
@@ -1,8 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
+  pkg.entry({root: './src/index.ts'});
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-stylelint/loom.config.ts
+++ b/packages/loom-plugin-stylelint/loom.config.ts
@@ -1,8 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
+  pkg.entry({root: './src/index.ts'});
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-typescript/loom.config.ts
+++ b/packages/loom-plugin-typescript/loom.config.ts
@@ -1,9 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
-  pkg.entry({root: './src/index'});
+  pkg.entry({root: './src/index.ts'});
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-webpack/loom.config.ts
+++ b/packages/loom-plugin-webpack/loom.config.ts
@@ -1,10 +1,9 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
-  pkg.entry({root: './src/index'});
-  pkg.entry({name: 'noop', root: './src/noop'});
+  pkg.entry({root: './src/index.ts'});
+  pkg.entry({name: 'noop', root: './src/noop.ts'});
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom/loom.config.ts
+++ b/packages/loom/loom.config.ts
@@ -1,10 +1,9 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
-  pkg.entry({root: './src/index'});
-  pkg.entry({root: './src/config-load', name: 'config-load'});
+  pkg.entry({root: './src/index.ts'});
+  pkg.entry({root: './src/config-load.ts', name: 'config-load'});
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom/src/config-load.ts
+++ b/packages/loom/src/config-load.ts
@@ -119,10 +119,7 @@ export async function loadWorkspace(root: string): Promise<LoadedWorkspace> {
   for (const {kind, options, projectPlugins} of loadedConfigs) {
     switch (kind) {
       case ConfigurationKind.Package: {
-        const pkg = new Package({
-          entries: [{root: './src/index', runtime: (options as any).runtime}],
-          ...options,
-        } as any);
+        const pkg = new Package(options as any);
         packages.add(pkg);
         pluginMap.set(pkg, projectPlugins);
         break;

--- a/packages/loom/src/config/README.md
+++ b/packages/loom/src/config/README.md
@@ -37,8 +37,10 @@ import {createPackage, Runtime} from '@shopify/loom';
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  // tells loom that we're building a Node.js package
-  pkg.runtime(Runtime.Node);
+  // tell loom the entry point into your package.
+  pkg.entry({root: './src/index.js'});
+  // If your app has multiple entrypoints you can add additional entries
+  pkg.entry({name: 'second', root: './src/second.js'});
 
   // tell loom what kind of build outputs you want available
   pkg.use(createLoomPackagePlugin());

--- a/packages/loom/src/tests/config-load.test.ts
+++ b/packages/loom/src/tests/config-load.test.ts
@@ -15,7 +15,7 @@ const packageConfig = `
 import {createPackage} from '@shopify/loom';
 
 export default createPackage((pkg) => {
-  pkg.entry({root: '/src/index'});
+  pkg.entry({root: '/src/index.js'});
 })`;
 
 const defaultEntry = `

--- a/templates/loom.templateconfig.hbs.ts
+++ b/templates/loom.templateconfig.hbs.ts
@@ -1,8 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
+  pkg.entry({root: './src/index.ts'});
   pkg.use(createLoomPackagePlugin());
 });


### PR DESCRIPTION

## Description

TODO This got a bit out of hand as I dove deeper. I'll split this PR out into separate ones that can be reviewed individually

Fixes a few things, that could probably be separate PRs:

- Improve helpers for reading stdout/stderr in tests, including
  stripping ansi codes by default.
- Don't add a default implicit `./src/index` entry if you do not
  specify any entryfiles at all
- Ensure that entry roots are valid and present file paths instead of things paths
  that be transformed into file paths with `require.resolve()` - This
  means `./src/index` is no longer valid, you must do `./src/index.js`
- Remove unneeded runtimes from loom.config files now that #257 means it has no effect on compiled output


TODO: Make the entry `name` field required - `pkg.entry({root: 'src/index.js'})` will be invalid, you must do `pkg.entry({name: 'index', root: 'src/index.js'})` instead


## Type of change

