### PR TITLE
Remove runtimes from package loom configs

### DIFF
--- a/packages/loom-cli/loom.config.ts
+++ b/packages/loom-cli/loom.config.ts
@@ -1,9 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.entry({root: './src/index'});
   pkg.binary({name: 'loom', root: './src/cli'});
   pkg.use(createLoomPackagePlugin());

--- a/packages/loom-plugin-babel/README.md
+++ b/packages/loom-plugin-babel/README.md
@@ -19,7 +19,6 @@ import {createPackage, Runtime} from '@shopify/loom';
 import {babel} from '@shopify/loom-plugin-babel';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.use(
     babel({
       // Overrides any current config that is set
@@ -34,7 +33,6 @@ import {createPackage, Runtime} from '@shopify/loom';
 import {babel} from '@shopify/loom-plugin-babel';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.use(
     // Override initial babel options.
     // Return a new object, instead of mutating the argument object.

--- a/packages/loom-plugin-babel/loom.config.ts
+++ b/packages/loom-plugin-babel/loom.config.ts
@@ -1,9 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.entry({root: './src/index'});
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-build-library-extended/loom.config.ts
+++ b/packages/loom-plugin-build-library-extended/loom.config.ts
@@ -1,9 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.entry({root: './src/index'});
   pkg.entry({name: 'transform-style', root: './src/jest/transform-style'});
   pkg.entry({name: 'transform-svg', root: './src/jest/transform-svg'});

--- a/packages/loom-plugin-build-library/loom.config.ts
+++ b/packages/loom-plugin-build-library/loom.config.ts
@@ -1,9 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.entry({root: './src/index'});
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-eslint/loom.config.ts
+++ b/packages/loom-plugin-eslint/loom.config.ts
@@ -1,8 +1,7 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-jest/loom.config.ts
+++ b/packages/loom-plugin-jest/loom.config.ts
@@ -1,8 +1,7 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-prettier/loom.config.ts
+++ b/packages/loom-plugin-prettier/loom.config.ts
@@ -1,8 +1,7 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-rollup/loom.config.ts
+++ b/packages/loom-plugin-rollup/loom.config.ts
@@ -1,8 +1,7 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-stylelint/loom.config.ts
+++ b/packages/loom-plugin-stylelint/loom.config.ts
@@ -1,8 +1,7 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-typescript/loom.config.ts
+++ b/packages/loom-plugin-typescript/loom.config.ts
@@ -1,9 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.entry({root: './src/index'});
   pkg.use(createLoomPackagePlugin());
 });

--- a/packages/loom-plugin-webpack/loom.config.ts
+++ b/packages/loom-plugin-webpack/loom.config.ts
@@ -1,9 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.entry({root: './src/index'});
   pkg.entry({name: 'noop', root: './src/noop'});
   pkg.use(createLoomPackagePlugin());

--- a/packages/loom/loom.config.ts
+++ b/packages/loom/loom.config.ts
@@ -1,9 +1,8 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.entry({root: './src/index'});
   pkg.entry({root: './src/config-load', name: 'config-load'});
   pkg.use(createLoomPackagePlugin());

--- a/packages/loom/src/config/README.md
+++ b/packages/loom/src/config/README.md
@@ -37,8 +37,10 @@ import {createPackage, Runtime} from '@shopify/loom';
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  // tells loom that we're building a Node.js package
-  pkg.runtime(Runtime.Node);
+  // tell loom the main entry point of your package.
+  pkg.entry({name: 'index', root: './src/index.js'});
+  // If your app has multiple entrypoints you can add additional entries
+  pkg.entry({name: 'second', root: './src/second.js'});
 
   // tell loom what kind of build outputs you want available
   pkg.use(createLoomPackagePlugin());

--- a/templates/loom.templateconfig.hbs.ts
+++ b/templates/loom.templateconfig.hbs.ts
@@ -1,8 +1,7 @@
-import {createPackage, Runtime} from '@shopify/loom';
+import {createPackage} from '@shopify/loom';
 
 import {createLoomPackagePlugin} from '../../config/loom';
 
 export default createPackage((pkg) => {
-  pkg.runtime(Runtime.Node);
   pkg.use(createLoomPackagePlugin());
 });


### PR DESCRIPTION
## Description

Setting a runtime no longer has any effect on build output, after the merge of #257 , it is just noise.

- Remove setting runtimes in our package loom configs.
- Remove a reference to pkg.runtime in a README as it doesn't have any bearing

## Type of change

This does not effect build output